### PR TITLE
Development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,14 @@ find_package(jsoncpp REQUIRED)
 ## Local dependencies
 add_subdirectory(dep)
 
+set(CA_PATH "${PROJECT_SOURCE_DIR}/certs/aws-root-ca.pem")
+set(CERT_PATH "${PROJECT_SOURCE_DIR}/certs/certificate.pem.crt")
+set(KEY_PATH "${PROJECT_SOURCE_DIR}/certs/private.pem.key")
+
+add_definitions(-DCA_PATH=\"${CA_PATH}\")
+add_definitions(-DCERT_PATH=\"${CERT_PATH}\")
+add_definitions(-DKEY_PATH=\"${KEY_PATH}\")
+
 ###################################
 ## catkin specific configuration ##
 ###################################
@@ -69,11 +77,6 @@ target_link_libraries(${PROJECT_NAME}
     cpr::cpr
     ${catkin_LIBRARIES}
 )
-
-## Copy Certificates into build directory
-FILE(COPY certs/aws-root-ca.pem DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
-FILE(COPY certs/certificate.pem.crt DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
-FILE(COPY certs/private.pem.key DESTINATION "${CMAKE_CURRENT_BINARY_DIR}")
 
 #############
 ## Install ##

--- a/src/iort_lib/iort.cpp
+++ b/src/iort_lib/iort.cpp
@@ -125,9 +125,9 @@ void Subscriber::run(std::future<void> exitSig)
 {
     mqtt::async_client cli(ENDPOINT_URL, "client_" + std::to_string(id++));
     auto sslopts = mqtt::ssl_options_builder()
-               .private_key("build/iort_lib/private.pem.key")
-		.key_store("build/iort_lib/certificate.pem.crt")
-		.trust_store("build/iort_lib/aws-root-ca.pem")
+               .private_key(KEY_PATH)
+		.key_store(CERT_PATH)
+		.trust_store(CA_PATH)
 		.private_keypassword("")
 		.ssl_version(3)
 		.error_handler([](const std::string& msg) {
@@ -153,7 +153,7 @@ void Subscriber::run(std::future<void> exitSig)
     {
         Json::Value payload;
         mqtt::const_message_ptr msg;
-        if (!cli.try_consume_message_for(&msg, 1ms))
+        if (!cli.try_consume_message_for(&msg, 10ms))
             continue;
         reader.parse(msg->to_string(), payload);
 #ifdef DEBUG


### PR DESCRIPTION
Fixed path issue that made using the library only work if the program was ran from the top directory of the workspace that the library was built in. Should work anywhere now.